### PR TITLE
Fixed errors with the team command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>mc.alk</groupId>
     <artifactId>BattleArena</artifactId>
     <packaging>jar</packaging>
-    <version>3.9.10.4</version>
+    <version>3.9.10.5</version>
     <name>BattleArena</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/java/mc/alk/arena/executors/TeamExecutor.java
+++ b/src/java/mc/alk/arena/executors/TeamExecutor.java
@@ -41,7 +41,7 @@ public class TeamExecutor extends CustomCommandExecutor {
 		return sendMessage(sender,sb.toString());
 	}
 
-	@MCCommand(cmds={"join"}, usage="join", perm="arena.team.join")
+	@MCCommand(cmds={"join", "accept"}, usage="join", perm="arena.team.join")
 	public boolean teamJoin(ArenaPlayer player) {
 
 		ArenaTeam t = teamc.getSelfFormedTeam(player);
@@ -120,14 +120,14 @@ public class TeamExecutor extends CustomCommandExecutor {
 		/// Finally ready to create a team
 		FormingTeam ft = new FormingTeam(player, foundArenaPlayers);
 		teamc.addFormingTeam(ft);
-		sendMessage(player,ChatColor.YELLOW + "You are now forming a team. The others must accept by using &6/team add");
+		sendMessage(player,ChatColor.YELLOW + "You are now forming a team. The others must accept by using &6/team accept");
 
 		/// Send a message to the other teammates
 		for (ArenaPlayer p: ft.getPlayers()){
 			if (player.equals(p))
 				continue;
 			sendMessage(p, "&eYou have been invited to a team with &6" + ft.getOtherNames(player));
-			sendMessage(p, "&6/team add&e : to accept: &6/team decline&e to refuse ");
+			sendMessage(p, "&6/team accept&e : to accept: &6/team decline&e to refuse ");
 		}
 		return true;
 	}


### PR DESCRIPTION
I fixed some old errors in the team command where some info strings were not updated after the "/team add" command was refactored to "/team join". I also added "/team accept" as an alias to "/team join" per request of supawiz6991. 