### PR TITLE
Fix bug in HeroesUtil.java

### DIFF
--- a/src/java/mc/alk/arena/util/plugins/HeroesUtil.java
+++ b/src/java/mc/alk/arena/util/plugins/HeroesUtil.java
@@ -99,9 +99,7 @@ public abstract class HeroesUtil {
         if (hero == null) {
             return;
         }
-        for (Effect effect : hero.getEffects()) {
-            hero.removeEffect(effect);
-        }
+	hero.clearEffects();
     }
 
     public static HeroParty createParty(ArenaTeam team, Hero hero) {


### PR DESCRIPTION
Currently there's a bug where when entering an arena a loop is called removing all effects which is affecting passive abilities. This commit removes that loop and uses the safer way to do it heroes.ClearEffects() so it doesn't affect passive abilities on heroes classes.