### PR TITLE
Min/Max editor permission fix

### DIFF
--- a/plugin/src/main/java/org/battleplugins/arena/util/InteractionInputs.java
+++ b/plugin/src/main/java/org/battleplugins/arena/util/InteractionInputs.java
@@ -172,6 +172,9 @@ public class InteractionInputs {
 
                 @EventHandler
                 public void onInteract(PlayerInteractEvent event) {
+                    if (!player.equals(event.getPlayer())) {
+                        return;
+                    }
                     if (event.getAction() != Action.RIGHT_CLICK_BLOCK && event.getAction() != Action.LEFT_CLICK_BLOCK) {
                         return;
                     }


### PR DESCRIPTION
Fixed anyone being able to set min max when editing an arena. now only the correct person in the editor wizard can.