### PR TITLE
Dynamic arena overhaul

### DIFF
--- a/plugin/src/main/java/org/battleplugins/arena/BattleArenaConfig.java
+++ b/plugin/src/main/java/org/battleplugins/arena/BattleArenaConfig.java
@@ -30,6 +30,12 @@ public class BattleArenaConfig {
     @ArenaOption(name = "randomized-arena-join", description = "Whether players should be randomly placed in an Arena when joining without specifying a map.", required = true)
     private boolean randomizedArenaJoin;
 
+    @ArenaOption(name = "use-schematic", description = "Whether creating a dynamic arena should try to use a schematic if one is available first.", required = true)
+    private boolean schematicUsage;
+
+    @ArenaOption(name = "center-dynamic-arena", description = "If true, pastes the dynamic arena centered at 0,0,0.", required = true)
+    private boolean centerDynamicArena;
+
     @ArenaOption(name = "disabled-modules", description = "Modules that are disabled by default.")
     private List<String> disabledModules;
 
@@ -57,6 +63,14 @@ public class BattleArenaConfig {
 
     public boolean isRandomizedArenaJoin() {
         return this.randomizedArenaJoin;
+    }
+
+    public boolean isSchematicUsage() {
+        return this.schematicUsage;
+    }
+
+    public boolean centerDynamicArena() {
+        return this.centerDynamicArena;
     }
 
     public List<String> getDisabledModules() {

--- a/plugin/src/main/java/org/battleplugins/arena/competition/map/LiveCompetitionMap.java
+++ b/plugin/src/main/java/org/battleplugins/arena/competition/map/LiveCompetitionMap.java
@@ -3,7 +3,6 @@ package org.battleplugins.arena.competition.map;
 import net.kyori.adventure.util.TriState;
 import org.battleplugins.arena.Arena;
 import org.battleplugins.arena.ArenaLike;
-import org.battleplugins.arena.competition.Competition;
 import org.battleplugins.arena.competition.LiveCompetition;
 import org.battleplugins.arena.competition.map.options.Bounds;
 import org.battleplugins.arena.competition.map.options.Spawns;
@@ -14,7 +13,9 @@ import org.battleplugins.arena.config.PostProcessable;
 import org.battleplugins.arena.util.BlockUtil;
 import org.battleplugins.arena.util.Util;
 import org.battleplugins.arena.util.VoidChunkGenerator;
+import org.battleplugins.arena.BattleArenaConfig;
 import org.bukkit.Bukkit;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
@@ -254,9 +255,16 @@ public class LiveCompetitionMap implements ArenaLike, CompetitionMap, PostProces
         if (world == null) {
             return null;
         }
+        world.setGameRule(GameRule.DISABLE_RAIDS, true);
 
-        if (!BlockUtil.copyToWorld(this.mapWorld, world, this.bounds)) {
-            return null; // Failed to copy
+        BattleArenaConfig config = this.getArena().getPlugin().getMainConfig();
+
+        // If schematic usage is disabled in the config OR schematic pasting fails,
+        // then attempt to fall back to copying the map directly from the map world.
+        // If that also fails, return null to indicate map setup failure.
+        if ((!config.isSchematicUsage() || !BlockUtil.pasteSchematic(this))
+            && !BlockUtil.copyToWorld(this.mapWorld, world, this.bounds, config.centerDynamicArena())) {
+            return null;
         }
 
         LiveCompetitionMap copy = arena.getMapFactory().create(this.name, arena, this.type, worldName, this.bounds, this.spawns);

--- a/plugin/src/main/java/org/battleplugins/arena/competition/map/LiveCompetitionMap.java
+++ b/plugin/src/main/java/org/battleplugins/arena/competition/map/LiveCompetitionMap.java
@@ -256,13 +256,14 @@ public class LiveCompetitionMap implements ArenaLike, CompetitionMap, PostProces
             return null;
         }
         world.setGameRule(GameRule.DISABLE_RAIDS, true);
+        world.setAutoSave(false);
 
         BattleArenaConfig config = this.getArena().getPlugin().getMainConfig();
 
         // If schematic usage is disabled in the config OR schematic pasting fails,
         // then attempt to fall back to copying the map directly from the map world.
         // If that also fails, return null to indicate map setup failure.
-        if ((!config.isSchematicUsage() || !BlockUtil.pasteSchematic(this))
+        if ((!config.isSchematicUsage() || !BlockUtil.pasteSchematic(this, world))
             && !BlockUtil.copyToWorld(this.mapWorld, world, this.bounds, config.centerDynamicArena())) {
             return null;
         }

--- a/plugin/src/main/java/org/battleplugins/arena/event/action/types/TeleportAction.java
+++ b/plugin/src/main/java/org/battleplugins/arena/event/action/types/TeleportAction.java
@@ -2,6 +2,8 @@ package org.battleplugins.arena.event.action.types;
 
 import org.battleplugins.arena.ArenaPlayer;
 import org.battleplugins.arena.competition.Competition;
+import org.battleplugins.arena.competition.map.options.Bounds;
+import org.bukkit.util.Vector;
 import org.battleplugins.arena.competition.map.options.TeamSpawns;
 import org.battleplugins.arena.event.action.EventAction;
 import org.battleplugins.arena.resolver.Resolvable;
@@ -31,6 +33,14 @@ public class TeleportAction extends EventAction {
         TeleportLocation location = TeleportLocation.valueOf(this.get(LOCATION_KEY).toUpperCase(Locale.ROOT));
         boolean randomized = Boolean.parseBoolean(this.getOrDefault(RANDOM, "false"));
 
+        boolean centerDynamicArena = arenaPlayer.getCompetition().getArena().getPlugin().getMainConfig().centerDynamicArena();
+        Bounds bounds = arenaPlayer.getCompetition().getMap().getBounds();
+        Vector center = new Vector(
+            (bounds.getMaxX() - bounds.getMinX()) / 2.0,
+            bounds.getMinY(),
+            (bounds.getMaxZ() - bounds.getMinZ()) / 2.0
+        );
+
         PositionWithRotation pos = switch (location) {
             case LAST_LOCATION:
                 Location lastLocation = arenaPlayer.getStorage().getLastLocation();
@@ -40,9 +50,11 @@ public class TeleportAction extends EventAction {
                     yield null;
                 }
             case WAITROOM:
-                yield arenaPlayer.getCompetition().getMap().getSpawns().getWaitroomSpawn();
+                PositionWithRotation waitroomSpawn = arenaPlayer.getCompetition().getMap().getSpawns().getWaitroomSpawn();
+                yield centerDynamicArena ? centerOffsetPosition(waitroomSpawn, center) : waitroomSpawn;
             case SPECTATOR:
-                yield arenaPlayer.getCompetition().getMap().getSpawns().getSpectatorSpawn();
+                PositionWithRotation spectatorSpawn = arenaPlayer.getCompetition().getMap().getSpawns().getSpectatorSpawn();
+                yield centerDynamicArena ? centerOffsetPosition(spectatorSpawn, center) : spectatorSpawn;
             case TEAM_SPAWN:
                 Map<String, TeamSpawns> teamSpawns = arenaPlayer.getCompetition().getMap().getSpawns().getTeamSpawns();
                 if (teamSpawns == null) {
@@ -62,11 +74,13 @@ public class TeleportAction extends EventAction {
 
                 // Fast track if there is only one spawn
                 if (spawns.size() == 1) {
-                    yield spawns.get(0);
+                    PositionWithRotation spawn = spawns.get(0);
+                    yield centerDynamicArena ? centerOffsetPosition(spawn, center) : spawn;
                 }
 
                 if (randomized) {
-                    yield spawns.get(ThreadLocalRandom.current().nextInt(spawns.size()));
+                    PositionWithRotation spawn = spawns.get(ThreadLocalRandom.current().nextInt(spawns.size()));
+                    yield centerDynamicArena ? centerOffsetPosition(spawn, center) : spawn;
                 }
 
                 // Get the spawn index for the team and increment it
@@ -74,7 +88,8 @@ public class TeleportAction extends EventAction {
                 this.spawnTeleportIndexQueue.put(arenaPlayer.getCompetition(), spawnIndex + 1);
 
                 // Get the spawn at the index
-                yield spawns.get(spawnIndex % spawns.size());
+                PositionWithRotation spawn = spawns.get(spawnIndex % spawns.size());
+                yield centerDynamicArena ? centerOffsetPosition(spawn, center) : spawn;
         };
 
         if (pos == null) {
@@ -90,4 +105,14 @@ public class TeleportAction extends EventAction {
         TEAM_SPAWN,
         LAST_LOCATION
     }
+
+    private static PositionWithRotation centerOffsetPosition(PositionWithRotation base, Vector offset) {
+    return new PositionWithRotation(
+        base.getX() - offset.getX(),
+        base.getY() - offset.getY(),
+        base.getZ() - offset.getZ(),
+        base.getYaw(),
+        base.getPitch()
+    );
+}
 }

--- a/plugin/src/main/java/org/battleplugins/arena/event/action/types/TeleportAction.java
+++ b/plugin/src/main/java/org/battleplugins/arena/event/action/types/TeleportAction.java
@@ -4,6 +4,7 @@ import org.battleplugins.arena.ArenaPlayer;
 import org.battleplugins.arena.competition.Competition;
 import org.battleplugins.arena.competition.map.options.Bounds;
 import org.bukkit.util.Vector;
+import org.battleplugins.arena.competition.map.MapType;
 import org.battleplugins.arena.competition.map.options.TeamSpawns;
 import org.battleplugins.arena.event.action.EventAction;
 import org.battleplugins.arena.resolver.Resolvable;
@@ -33,12 +34,13 @@ public class TeleportAction extends EventAction {
         TeleportLocation location = TeleportLocation.valueOf(this.get(LOCATION_KEY).toUpperCase(Locale.ROOT));
         boolean randomized = Boolean.parseBoolean(this.getOrDefault(RANDOM, "false"));
 
-        boolean centerDynamicArena = arenaPlayer.getCompetition().getArena().getPlugin().getMainConfig().centerDynamicArena();
+        boolean centerDynamicArena = arenaPlayer.getCompetition().getArena().getPlugin().getMainConfig().centerDynamicArena()
+                && arenaPlayer.getCompetition().getMap().getType() == MapType.DYNAMIC;
         Bounds bounds = arenaPlayer.getCompetition().getMap().getBounds();
         Vector center = new Vector(
-            (bounds.getMaxX() - bounds.getMinX()) / 2.0,
+            (bounds.getMaxX() + bounds.getMinX()) / 2.0,
             bounds.getMinY(),
-            (bounds.getMaxZ() - bounds.getMinZ()) / 2.0
+            (bounds.getMaxZ() + bounds.getMinZ()) / 2.0
         );
 
         PositionWithRotation pos = switch (location) {
@@ -109,7 +111,7 @@ public class TeleportAction extends EventAction {
     private static PositionWithRotation centerOffsetPosition(PositionWithRotation base, Vector offset) {
     return new PositionWithRotation(
         base.getX() - offset.getX(),
-        base.getY() - offset.getY(),
+        base.getY(),
         base.getZ() - offset.getZ(),
         base.getYaw(),
         base.getPitch()

--- a/plugin/src/main/java/org/battleplugins/arena/util/BlockUtil.java
+++ b/plugin/src/main/java/org/battleplugins/arena/util/BlockUtil.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 
 import org.battleplugins.arena.BattleArena;
 import org.battleplugins.arena.competition.map.options.Bounds;
@@ -29,6 +30,62 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 
 public final class BlockUtil {
+
+    private static class SchematicData {
+        final Clipboard clipboard;
+        final BlockVector3 pasteLocation;
+
+        SchematicData(Clipboard clipboard, BlockVector3 pasteLocation) {
+            this.clipboard = clipboard;
+            this.pasteLocation = pasteLocation;
+        }
+    }
+
+    private static SchematicData loadSchematicData(LiveCompetitionMap map, World world) {
+        Path path = map.getArena().getPlugin().getDataFolder().toPath()
+                .resolve("schematics")
+                .resolve(map.getArena().getName().toLowerCase(Locale.ROOT))
+                .resolve(map.getName().toLowerCase(Locale.ROOT) + "." +
+                        BuiltInClipboardFormat.SPONGE_SCHEMATIC.getPrimaryFileExtension()
+                );
+
+        if (Files.notExists(path)) {
+            Bukkit.getLogger().warning("Schematic not found: " + path);
+            return null;
+        }
+
+        ClipboardFormat format = ClipboardFormats.findByFile(path.toFile());
+        if (format == null) {
+            Bukkit.getLogger().warning("Unknown schematic format: " + path.getFileName());
+            return null;
+        }
+
+        Clipboard clipboard;
+        try (ClipboardReader reader = format.getReader(Files.newInputStream(path))) {
+            clipboard = reader.read();
+        } catch (IOException e) {
+            Bukkit.getLogger().severe("Failed to read schematic: " + e.getMessage());
+            return null;
+        }
+
+        Bounds bounds = map.getBounds();
+        BlockVector3 pasteLocation;
+        if (map.getArena().getPlugin().getMainConfig().centerDynamicArena()) {
+            int widthX = bounds.getMaxX() - bounds.getMinX();
+            int y = bounds.getMinY();
+            int widthZ = bounds.getMaxZ() - bounds.getMinZ();
+
+            pasteLocation = BlockVector3.at(
+                    -widthX / 2,
+                    y,
+                    -widthZ / 2
+            );
+        } else {
+            pasteLocation = BlockVector3.at(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ());
+        }
+
+        return new SchematicData(clipboard, pasteLocation);
+    }
 
     public static boolean copyToWorld(World oldWorld, World newWorld, Bounds bounds, boolean center) {
         CuboidRegion region = new CuboidRegion(BlockVector3.at(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ()), BlockVector3.at(bounds.getMaxX(), bounds.getMaxY(), bounds.getMaxZ()));
@@ -62,6 +119,7 @@ public final class BlockUtil {
         try (EditSession session = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(newWorld))) {
             Operation operation = new ClipboardHolder(clipboard).createPaste(session)
                     .to(pasteLocation)
+                    .ignoreAirBlocks(true)
                     .build();
 
             Operations.complete(operation);
@@ -74,53 +132,18 @@ public final class BlockUtil {
         return true;
     }
 
-    public static boolean pasteSchematic(LiveCompetitionMap map) {
-        Path path = map.getArena().getPlugin().getDataFolder().toPath()
-            .resolve("schematics")
-            .resolve(map.getArena().getName().toLowerCase(Locale.ROOT))
-            .resolve(map.getName().toLowerCase(Locale.ROOT) + "." +
-                BuiltInClipboardFormat.SPONGE_SCHEMATIC.getPrimaryFileExtension()
-            );
-        if (Files.notExists(path)) {
-            Bukkit.getLogger().warning("Schematic not found: " + path.toString());
+    public static boolean pasteSchematic(LiveCompetitionMap map, World world) {
+        SchematicData data = loadSchematicData(map, world);
+        if (data == null) {
             return false;
         }
 
-        ClipboardFormat format = ClipboardFormats.findByFile(path.toFile());
-        if (format == null) {
-            Bukkit.getLogger().warning("Unknown schematic format: " + path.getFileName());
-            return false;
-        }
-
-        Clipboard clipboard;
-        try (ClipboardReader reader = format.getReader(Files.newInputStream(path))) {
-            clipboard = reader.read();
-        } catch (IOException e) {
-            Bukkit.getLogger().severe("Failed to read schematic: " + e.getMessage());
-            return false;
-        }
-    
-        BlockVector3 pasteLocation;
-        Bounds bounds = map.getBounds();
-
-        if (map.getArena().getPlugin().getMainConfig().centerDynamicArena()) {
-            int widthX = bounds.getMaxX() - bounds.getMinX();
-            int Y = bounds.getMinY();
-            int widthZ = bounds.getMaxZ() - bounds.getMinZ();
-
-            pasteLocation = BlockVector3.at(
-                -widthX / 2,
-                Y,
-                -widthZ / 2
-            );
-        } else {
-            pasteLocation = BlockVector3.at(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ());
-        }
-
-        try (EditSession session = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(map.getWorld()))) {
-            Operation operation = new ClipboardHolder(clipboard).createPaste(session)
-                .to(pasteLocation)
-                .build();
+        try (EditSession session = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(world))) {
+            Operation operation = new ClipboardHolder(data.clipboard)
+                    .createPaste(session)
+                    .to(data.pasteLocation)
+                    .ignoreAirBlocks(true)
+                    .build();
 
             Operations.complete(operation);
             return true;
@@ -128,5 +151,29 @@ public final class BlockUtil {
             Bukkit.getLogger().severe("Failed to paste schematic: " + e.getMessage());
             return false;
         }
+    }
+
+    // for future use somewhere? safer and efficent
+    public static CompletableFuture<Boolean> pasteSchematicAsync(LiveCompetitionMap map, World world) {
+        SchematicData data = loadSchematicData(map, world);
+        if (data == null) {
+            return CompletableFuture.completedFuture(false);
+        }
+
+        return CompletableFuture.supplyAsync(() -> {
+            try (EditSession session = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(world))) {
+                Operation operation = new ClipboardHolder(data.clipboard)
+                        .createPaste(session)
+                        .to(data.pasteLocation)
+                        .ignoreAirBlocks(true)
+                        .build();
+
+                Operations.complete(operation);
+                return true;
+            } catch (WorldEditException e) {
+                e.printStackTrace();
+                return false;
+            }
+        });
     }
 }

--- a/plugin/src/main/java/org/battleplugins/arena/util/BlockUtil.java
+++ b/plugin/src/main/java/org/battleplugins/arena/util/BlockUtil.java
@@ -5,19 +5,32 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.extent.clipboard.io.BuiltInClipboardFormat;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormats;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
 import com.sk89q.worldedit.function.operation.ForwardExtentCopy;
 import com.sk89q.worldedit.function.operation.Operation;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.session.ClipboardHolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
 import org.battleplugins.arena.BattleArena;
 import org.battleplugins.arena.competition.map.options.Bounds;
+import org.battleplugins.arena.competition.map.LiveCompetitionMap;
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 
 public final class BlockUtil {
 
-    public static boolean copyToWorld(World oldWorld, World newWorld, Bounds bounds) {
+    public static boolean copyToWorld(World oldWorld, World newWorld, Bounds bounds, boolean center) {
         CuboidRegion region = new CuboidRegion(BlockVector3.at(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ()), BlockVector3.at(bounds.getMaxX(), bounds.getMaxY(), bounds.getMaxZ()));
         BlockArrayClipboard clipboard = new BlockArrayClipboard(region);
         ForwardExtentCopy copy = new ForwardExtentCopy(BukkitAdapter.adapt(oldWorld), region, clipboard, region.getMinimumPoint());
@@ -30,9 +43,25 @@ public final class BlockUtil {
             return false;
         }
 
+        BlockVector3 pasteLocation;
+
+        if (center) {
+            int widthX = bounds.getMaxX() - bounds.getMinX();
+            int Y = bounds.getMinY();
+            int widthZ = bounds.getMaxZ() - bounds.getMinZ();
+
+            pasteLocation = BlockVector3.at(
+                -widthX / 2,
+                Y,
+                -widthZ / 2
+            );
+        } else {
+            pasteLocation = BlockVector3.at(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ());
+        }
+
         try (EditSession session = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(newWorld))) {
             Operation operation = new ClipboardHolder(clipboard).createPaste(session)
-                    .to(BlockVector3.at(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ()))
+                    .to(pasteLocation)
                     .build();
 
             Operations.complete(operation);
@@ -43,5 +72,61 @@ public final class BlockUtil {
         }
 
         return true;
+    }
+
+    public static boolean pasteSchematic(LiveCompetitionMap map) {
+        Path path = map.getArena().getPlugin().getDataFolder().toPath()
+            .resolve("schematics")
+            .resolve(map.getArena().getName().toLowerCase(Locale.ROOT))
+            .resolve(map.getName().toLowerCase(Locale.ROOT) + "." +
+                BuiltInClipboardFormat.SPONGE_SCHEMATIC.getPrimaryFileExtension()
+            );
+        if (Files.notExists(path)) {
+            Bukkit.getLogger().warning("Schematic not found: " + path.toString());
+            return false;
+        }
+
+        ClipboardFormat format = ClipboardFormats.findByFile(path.toFile());
+        if (format == null) {
+            Bukkit.getLogger().warning("Unknown schematic format: " + path.getFileName());
+            return false;
+        }
+
+        Clipboard clipboard;
+        try (ClipboardReader reader = format.getReader(Files.newInputStream(path))) {
+            clipboard = reader.read();
+        } catch (IOException e) {
+            Bukkit.getLogger().severe("Failed to read schematic: " + e.getMessage());
+            return false;
+        }
+    
+        BlockVector3 pasteLocation;
+        Bounds bounds = map.getBounds();
+
+        if (map.getArena().getPlugin().getMainConfig().centerDynamicArena()) {
+            int widthX = bounds.getMaxX() - bounds.getMinX();
+            int Y = bounds.getMinY();
+            int widthZ = bounds.getMaxZ() - bounds.getMinZ();
+
+            pasteLocation = BlockVector3.at(
+                -widthX / 2,
+                Y,
+                -widthZ / 2
+            );
+        } else {
+            pasteLocation = BlockVector3.at(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ());
+        }
+
+        try (EditSession session = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(map.getWorld()))) {
+            Operation operation = new ClipboardHolder(clipboard).createPaste(session)
+                .to(pasteLocation)
+                .build();
+
+            Operations.complete(operation);
+            return true;
+        } catch (WorldEditException e) {
+            Bukkit.getLogger().severe("Failed to paste schematic: " + e.getMessage());
+            return false;
+        }
     }
 }

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -23,6 +23,17 @@ max-dynamic-maps: 5
 # enabled.
 randomized-arena-join: false
 
+# Whether dynamic arenas should try to use a schematic file for the map if one is available.
+# If enabled and a schematic exists for the arena, it will be pasted into the world automatically.
+# If no schematic is found or pasting fails, the plugin will fall back to copying the map directly
+# from the source world. Disabling this option will skip the schematic step entirely and always
+# use world copying instead.
+use-schematic: false
+
+# If true, dynamic arenas (schematic or copied) will be pasted centered around 0,0,0.
+# If false, they will be pasted at their original saved coordinates.
+center-dynamic-arena: false
+
 # Modules that are disabled by default. BattleArena comes pre-installed with
 # multiple modules that can be disabled below if their behavior is not desired
 # Example for disabling the parties module:


### PR DESCRIPTION
A much more efficient, optimized, and versatile dynamic arena. configurable to work like normal through moving blocks from world to world while also retaining the bonuses. by using schematics you can remove the arena from your main world freeing the space up without players interacting with it. by setting center dynamic in config can force either schematic placing (if enabled in config) or the block moving (old default way) to be centered in the new world. this allows for bedrock users to join easier as they have unique chunk loading, and if too far makes it much longer load time for everyone. 
the new additions are completly versatile and optimal and optional. if schematic placing fails for any reason it falls back to the old method, and centering calculations cannot fail (its math). the optimizations on schematic placing are also on the old method of block moving, meaning you get the bonuses without having to change anything. 