### PR TITLE
Fix duel joins running asynchronously

### DIFF
--- a/module/duels/src/main/java/org/battleplugins/arena/module/duels/Duels.java
+++ b/module/duels/src/main/java/org/battleplugins/arena/module/duels/Duels.java
@@ -108,7 +108,7 @@ public class Duels implements ArenaModuleInitializer {
 
             // Force the game into the in-game state
             competition.getPhaseManager().setPhase(CompetitionPhaseType.INGAME);
-        });
+        }, Bukkit.getScheduler().getMainThreadExecutor(arena.getPlugin()));
     }
 
     private CompletableFuture<LiveCompetition<?>> findOrJoinCompetition(Arena arena) {


### PR DESCRIPTION
## Fix duel acceptance after the asynchronous FAWE update

`Duels.acceptDuel()` used `whenCompleteAsync()` without specifying an executor. As a result, `competition.join()` and phase changes ran on the common worker pool.

On Paper, this prevented the synchronous `ArenaJoinEvent` from executing and left the accepting player partially registered without teleporting either player.

## Changes

Run the completion callback using Bukkit’s main-thread executor:

```java
Bukkit.getScheduler().getMainThreadExecutor(arena.getPlugin())
```

This keeps asynchronous arena preparation intact while ensuring that player joins, events, teleports, and phase changes occur on the server thread.

## Testing

* Sent and accepted a duel using an existing static competition.
* Confirmed that both players joined and were teleported.
* Confirmed that normal arena events and phase transitions executed.
* Confirmed that the project builds successfully.
