### PR TITLE
Respect configured phase progression for duels

### DIFF
--- a/module/duels/src/main/java/org/battleplugins/arena/module/duels/Duels.java
+++ b/module/duels/src/main/java/org/battleplugins/arena/module/duels/Duels.java
@@ -7,7 +7,6 @@ import org.battleplugins.arena.competition.LiveCompetition;
 import org.battleplugins.arena.competition.PlayerRole;
 import org.battleplugins.arena.competition.map.LiveCompetitionMap;
 import org.battleplugins.arena.competition.map.MapType;
-import org.battleplugins.arena.competition.phase.CompetitionPhaseType;
 import org.battleplugins.arena.event.arena.ArenaCreateExecutorEvent;
 import org.battleplugins.arena.event.player.ArenaPreJoinEvent;
 import org.battleplugins.arena.messages.Messages;
@@ -105,9 +104,6 @@ public class Duels implements ArenaModuleInitializer {
                 competition.join(player, PlayerRole.PLAYING, team1);
                 competition.join(target, PlayerRole.PLAYING, team2);
             }
-
-            // Force the game into the in-game state
-            competition.getPhaseManager().setPhase(CompetitionPhaseType.INGAME);
         }, Bukkit.getScheduler().getMainThreadExecutor(arena.getPlugin()));
     }
 


### PR DESCRIPTION
## Allow duels to follow configured arena phase progression

### Summary

Allow duels to follow the arena’s configured phase progression instead of forcing the competition directly into `INGAME`.

### Problem

After both players join, the Duels module explicitly sets the phase to `INGAME`. This bypasses any configured intermediate phase, such as a kit-selection countdown.

For example, with an arena configured as:

```yaml
waiting:
  next-phase: countdown

countdown:
  next-phase: ingame
```

Duels currently skip the `countdown` phase entirely.

### Changes

Remove the explicit `INGAME` phase transition from `Duels.acceptDuel()`.

`WaitingPhase` already detects when enough players have joined and advances to its configured next phase. This allows each arena to control its own lifecycle without hardcoding a specific phase in the Duels module.

### Testing

* Accepted a duel in an arena configured with `waiting → countdown → ingame`.
* Confirmed that both players joined the competition.
* Confirmed that the countdown phase started.
* Confirmed that the competition advanced to `INGAME` after the countdown.
* Confirmed that arenas can still transition directly to `INGAME` by configuring it as the waiting phase’s next phase.
