### PR TITLE
Fix explicit subcommands resolving as command arguments

### DIFF
--- a/plugin/src/main/java/org/battleplugins/arena/command/BaseCommandExecutor.java
+++ b/plugin/src/main/java/org/battleplugins/arena/command/BaseCommandExecutor.java
@@ -403,23 +403,27 @@ public class BaseCommandExecutor implements TabExecutor {
     }
 
     private List<CommandWrapper> getCommandWrappers(String command, String subCommand) {
-        List<CommandWrapper> wrappers = new ArrayList<>();
-
+        List<CommandWrapper> genericWrappers = new ArrayList<>();
+        List<CommandWrapper> explicitWrappers = new ArrayList<>();
+    
         for (String cmd : this.commandWrappers.keySet()) {
             for (CommandWrapper wrapper : this.commandWrappers.get(cmd)) {
                 ArenaCommand arenaCommand = wrapper.getCommand();
-
+    
                 if (!Arrays.asList(arenaCommand.commands()).contains(command)) {
                     continue;
                 }
-
-                if (Arrays.asList(arenaCommand.subCommands()).isEmpty() || Arrays.asList(arenaCommand.subCommands()).contains(subCommand)) {
-                    wrappers.add(wrapper);
+    
+                List<String> subCommands = Arrays.asList(arenaCommand.subCommands());
+                if (subCommands.contains(subCommand)) {
+                    explicitWrappers.add(wrapper);
+                } else if (subCommands.isEmpty()) {
+                    genericWrappers.add(wrapper);
                 }
             }
         }
-
-        return wrappers;
+    
+        return explicitWrappers.isEmpty() ? genericWrappers : explicitWrappers;
     }
 
     private Object verifyArgument(CommandSender sender, String arg, Class<?> parameter) {


### PR DESCRIPTION
## Prioritize explicit subcommands over generic positional arguments

### Summary

Prioritize explicit subcommands over generic positional-argument commands.

### Problem

`getCommandWrappers()` currently returns both the generic command wrapper and the matching explicit subcommand wrapper.

For `/arena duel cancel`, both of the following commands match:

* `/arena duel <player>`
* `/arena duel cancel`

Because the wrappers are stored in a `HashSet`, their execution order is undefined. The generic wrapper may execute first and interpret `cancel` as a player name, preventing the actual cancel subcommand from running.

The same ambiguity can affect the `accept` and `deny` subcommands.

### Changes

* Separate explicit subcommand matches from generic command matches.
* Use explicit wrappers whenever the supplied argument matches a registered subcommand.
* Fall back to generic wrappers only when no explicit subcommand matches.

This preserves `/arena duel <player>` while correctly resolving `accept`, `deny`, and `cancel`.

### Testing

* Confirmed that `/arena duel cancel` resolves to the cancel subcommand.
* Confirmed that `/arena duel accept <player>` and `/arena duel deny <player>` resolve correctly.
* Confirmed that `/arena duel <player>` continues to use the generic duel command.
