### PR TITLE
Fix health restoration after max-health changes

### DIFF
--- a/plugin/src/main/java/org/battleplugins/arena/competition/PlayerStorage.java
+++ b/plugin/src/main/java/org/battleplugins/arena/competition/PlayerStorage.java
@@ -4,6 +4,7 @@ import org.battleplugins.arena.ArenaPlayer;
 import org.battleplugins.arena.BattleArena;
 import org.battleplugins.arena.util.InventoryBackup;
 import org.battleplugins.arena.util.Util;
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -212,8 +213,28 @@ public class PlayerStorage {
     }
 
     private void restoreHealth() {
-        this.player.getPlayer().setHealth(this.health);
-        this.player.getPlayer().setFoodLevel(this.hunger);
+        Player player = this.player.getPlayer();
+        double storedHealth = this.health;
+    
+        player.setFoodLevel(this.hunger);
+    
+        AttributeInstance attribute = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        if (attribute != null && storedHealth <= attribute.getValue()) {
+            player.setHealth(storedHealth);
+            return;
+        }
+    
+        // Inventory and attribute restoration can change max health after this method runs.
+        // Defer the write so equipment-related attribute changes have settled.
+        Bukkit.getScheduler().runTask(BattleArena.getInstance(), () -> {
+            AttributeInstance updatedAttribute =
+                    player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+    
+            if (updatedAttribute != null) {
+                // Prevent Paper from rejecting health above the current maximum.
+                player.setHealth(Math.min(storedHealth, updatedAttribute.getValue()));
+            }
+        });
     }
 
     private void restoreFlight() {


### PR DESCRIPTION
## Summary

Fixes player health restoration when arena equipment changes the player's maximum health.

## Problem

BattleArena restores player attributes and health during cleanup. Restored equipment can change `GENERIC_MAX_HEALTH`, causing `setHealth()` to run with a value that is invalid for the player's current maximum health.

This produces errors such as:

`Health value (...) must be between 0 and (...)`

and may leave the player's health incorrectly restored.

**Changes**

- Restore hunger immediately.
- Restore health immediately when it is valid for the current maximum health.
- Defer health restoration by one server tick when the maximum health may still change.
- Clamp the restored health to the updated maximum health.

**Testing**

- Verified normal health restoration.
- Verified restoration when equipment changes maximum health.
- Verified oversized stored health is clamped safely.
- Confirmed no health-range exception is thrown during arena cleanup.