### PR TITLE
Clean up both participants when a duel is cancelled before starting

### DIFF
--- a/module/duels/src/main/java/org/battleplugins/arena/module/duels/Duels.java
+++ b/module/duels/src/main/java/org/battleplugins/arena/module/duels/Duels.java
@@ -1,13 +1,18 @@
 package org.battleplugins.arena.module.duels;
 
 import org.battleplugins.arena.Arena;
+import org.battleplugins.arena.ArenaPlayer;
 import org.battleplugins.arena.competition.Competition;
 import org.battleplugins.arena.competition.JoinResult;
 import org.battleplugins.arena.competition.LiveCompetition;
 import org.battleplugins.arena.competition.PlayerRole;
 import org.battleplugins.arena.competition.map.LiveCompetitionMap;
 import org.battleplugins.arena.competition.map.MapType;
+import org.battleplugins.arena.competition.phase.CompetitionPhase;
+import org.battleplugins.arena.competition.phase.phases.CountdownPhase;
+import org.battleplugins.arena.competition.phase.phases.WaitingPhase;
 import org.battleplugins.arena.event.arena.ArenaCreateExecutorEvent;
+import org.battleplugins.arena.event.player.ArenaLeaveEvent;
 import org.battleplugins.arena.event.player.ArenaPreJoinEvent;
 import org.battleplugins.arena.messages.Messages;
 import org.battleplugins.arena.module.ArenaModule;
@@ -22,6 +27,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -34,6 +40,10 @@ public class Duels implements ArenaModuleInitializer {
     public static final JoinResult PENDING_REQUEST = new JoinResult(false, DuelsMessages.PENDING_DUEL_REQUEST);
 
     private final Map<UUID, UUID> duelRequests = new HashMap<>();
+
+    private enum DuelParticipant {
+        INSTANCE
+    }
 
     @EventHandler
     public void onCreateExecutor(ArenaCreateExecutorEvent event) {
@@ -61,6 +71,25 @@ public class Duels implements ArenaModuleInitializer {
     public void onPreJoin(ArenaPreJoinEvent event) {
         if (this.duelRequests.containsKey(event.getPlayer().getUniqueId())) {
             event.setResult(PENDING_REQUEST);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onLeave(ArenaLeaveEvent event) {
+        if (!event.getArena().isModuleEnabled(ID)
+                || event.getCause() == ArenaLeaveEvent.Cause.PLUGIN
+                || event.getArenaPlayer().getMetadata(DuelParticipant.class) == null) {
+            return;
+        }
+
+        LiveCompetition<?> competition = event.getArenaPlayer().getCompetition();
+        CompetitionPhase<?> phase = competition.getPhaseManager().getCurrentPhase();
+        if (!(phase instanceof WaitingPhase<?>) && !(phase instanceof CountdownPhase<?>)) {
+            return;
+        }
+
+        for (ArenaPlayer player : Set.copyOf(competition.getPlayers())) {
+            competition.leave(player, ArenaLeaveEvent.Cause.PLUGIN);
         }
     }
 
@@ -96,15 +125,26 @@ public class Duels implements ArenaModuleInitializer {
             // determined by the individual player who wins
             if (arena.getTeams().isNonTeamGame()) {
                 competition.join(player, PlayerRole.PLAYING);
+                markDuelParticipant(player);
                 competition.join(target, PlayerRole.PLAYING);
+                markDuelParticipant(target);
             } else {
                 ArenaTeam team1 = competition.getTeamManager().getTeams().iterator().next();
                 ArenaTeam team2 = competition.getTeamManager().getTeams().iterator().next();
 
                 competition.join(player, PlayerRole.PLAYING, team1);
+                markDuelParticipant(player);
                 competition.join(target, PlayerRole.PLAYING, team2);
+                markDuelParticipant(target);
             }
         }, Bukkit.getScheduler().getMainThreadExecutor(arena.getPlugin()));
+    }
+
+    private static void markDuelParticipant(Player player) {
+        ArenaPlayer arenaPlayer = ArenaPlayer.getArenaPlayer(player);
+        if (arenaPlayer != null) {
+            arenaPlayer.setMetadata(DuelParticipant.class, DuelParticipant.INSTANCE);
+        }
     }
 
     private CompletableFuture<LiveCompetition<?>> findOrJoinCompetition(Arena arena) {


### PR DESCRIPTION
## Summary

Remove both participants when a player leaves an accepted duel during its waiting or countdown phase.

## Problem

When a duel participant leaves during kit selection or countdown, only that player is removed from the competition.

The countdown reverts to the waiting phase because there are no longer enough players, but the opponent remains registered alone in the duel competition. Subsequent duel requests against that opponent fail because BattleArena still considers them to be in an arena.

This issue does not occur after gameplay begins. At that point, the active victory conditions already complete the match and clean up both players.

## Changes

- Mark players joined through `Duels.acceptDuel()` as duel participants.
- Handle duel participant leaves during the waiting and countdown phases.
- Remove all remaining participants through the normal `LiveCompetition.leave()` path.
- Use the `PLUGIN` leave cause and ignore that cause in the handler to prevent recursive cleanup.
- Preserve the existing in-game victory lifecycle.
- Avoid affecting players who joined an arena normally, even when that arena has the duels module enabled.

## Testing

Added regression coverage confirming that:

- Leaving during countdown removes the remaining duel participant.
- Leaving during gameplay does not interfere with normal victory handling.
- Plugin-triggered cleanup does not recurse.
- Ordinary arena participants do not trigger duel cleanup.
